### PR TITLE
Fix import path for accounting wrapper

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,7 @@ import { createWebHistory, createRouter } from "vue-router";
 import { useAuthStore } from "@/stores/authStore"; // Importa el store de autenticación
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import AuthLayout from "@/layouts/AuthLayout.vue";
+import BasicAccountingRecordsWrapper from "@/views/basicAccountingRecords/BasicAccountingRecordsWrapper.vue";
 
 // Definir rutas
 const routes = [
@@ -70,7 +71,7 @@ const routes = [
       {
         path: 'basicAccountingRecordsBook',
         name: 'BasicAccountingRecordsBook',
-        component: () => import('@/views/basicAccountingRecords/BasicAccountingRecordsWrapper.vue'),
+        component: BasicAccountingRecordsWrapper,
       },
       {
         path: 'basicAccountingRecordsBook/:registerId',

--- a/src/views/basicAccountingRecords/BasicAccountingRecordsWrapper.vue
+++ b/src/views/basicAccountingRecords/BasicAccountingRecordsWrapper.vue
@@ -1,18 +1,4 @@
-<!-- src/pages/BasicAccountingRecordsWrapper.vue
-<template>
-  <Suspense>
-    <template #default>
-      <AddRegister />
-    </template>
-    <template #fallback>
-      <div class="text-center p-6">Cargando formulario de registro...</div>
-    </template>
-  </Suspense>
-</template>
 
-<script setup>
-import AddRegister from "@/components/basicAccountingRecordsBook/AddRegister.vue";
-</script> -->
 
 <script setup>
 import { computed } from "vue";

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,8 +8,7 @@ export default defineConfig({
   // configure Vite to recognize the "@" symbol as the "src" folder in your project, you can modify the "resolve.alias"
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
-      '@api': path.resolve(__dirname, '../src/api'), // Nuevo alias para la carpeta 'src/api'
+      '@': path.resolve(__dirname, './src')
     }
   },
   plugins: [vue()],


### PR DESCRIPTION
## Summary
- clean up comment at the start of `BasicAccountingRecordsWrapper.vue`
- statically import the wrapper component in the router instead of lazy loading
- remove unused alias from Vite config

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e956cfc08832fa416bfc2a4bce4dd